### PR TITLE
Travis: remove sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,3 @@ script:
   - yarn test:routes
   - yarn test:a11y
   - yarn test:nsp
-# needed for newer yarn for a little bit: https://github.com/travis-ci/travis-ci/issues/7566#issuecomment-324138144
-group: edge
-sudo: required


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/RDM-2288

### Change description ###

sudo was needed for latest yarn, see
https://github.com/travis-ci/travis-ci/issues/7566#issuecomment-324138144
but this should have landed already

sudo builds take 25-30s to start the image, sudoless 1s

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
