### PR TITLE
Force use of HTTPS

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -35,6 +35,7 @@ module "ccd-admin-web" {
   is_frontend = "${local.is_frontend}"
   additional_host_name = "${local.external_host_name}"
   capacity = "${var.capacity}"
+  https_only = "${var.https_only}"
 
   app_settings = {
     // Node specific vars

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -64,3 +64,7 @@ variable "hpkp_sha256s" {
 variable "capacity" {
   default = "1"
 }
+
+variable "https_only" {
+  default = "true"
+}


### PR DESCRIPTION
Use the webapp https_only switch to force exposed apps to only use HTTPS.

### JIRA link ###
https://tools.hmcts.net/jira/browse/RDM-2367


### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
