### PR TITLE
Added yarn setup to Jenkins_CNP

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -10,5 +10,7 @@ def product = "ccd"
 def component = "admin-web"
 
 withPipeline("nodejs", product, component) {
-
+    after('build') {
+        sh 'yarn setup'
+  }
 }


### PR DESCRIPTION
Following test by QA on the AAT ENV , we found the static content CSS is not being generated as part of the deployed build for which we have added the change to create static content for the AAT ENV

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
