### PR TITLE
Shared ASP simplify our approach

### DIFF
--- a/infrastructure/demo.tfvars
+++ b/infrastructure/demo.tfvars
@@ -1,3 +1,5 @@
 idam_api_url = "https://preprod-idamapi.reform.hmcts.net:3511"
 authentication_web_url = "https://idam.preprod.ccidam.reform.hmcts.net"
 capacity = "2"
+asp_name = "ccd-shared-demo"
+asp_rg = "ccd-shared-demo"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -29,8 +29,6 @@ locals {
   previewStorageAccountName = "${var.raw_product}sharedaat"
   nonPreviewStorageAccountName = "${var.raw_product}shared${var.env}"
   storageAccountName = "${(var.env == "preview" || var.env == "spreview") ? local.previewStorageAccountName : local.nonPreviewStorageAccountName}"
-
-  sharedAppServicePlan = "${var.raw_product}-${var.env}"
 }
 
 data "azurerm_key_vault" "ccd_shared_key_vault" {
@@ -77,8 +75,8 @@ module "ccd-admin-web" {
   capacity = "${var.capacity}"
   https_only = "${var.https_only}"
   common_tags  = "${var.common_tags}"
-  asp_name = "${(var.asp_name == "use_shared") ? local.sharedAppServicePlan : var.asp_name}"
-  asp_rg = "${(var.asp_rg == "use_shared") ? local.sharedResourceGroup : var.asp_rg}"
+  asp_name = "${var.asp_name}"
+  asp_rg = "${var.asp_rg}"
 
   app_settings = {
     // Node specific vars

--- a/infrastructure/saat.tfvars
+++ b/infrastructure/saat.tfvars
@@ -1,1 +1,3 @@
 // authentication_web_url = "https://idam-web-public-idam-saat.service.core-compute-idam-saat.internal"
+asp_name = "ccd-shared-saat"
+asp_rg = "ccd-shared-saat"

--- a/infrastructure/sandbox.tfvars
+++ b/infrastructure/sandbox.tfvars
@@ -1,0 +1,2 @@
+asp_name = "ccd-shared-sandbox"
+asp_rg = "ccd-shared-sandbox"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -75,12 +75,12 @@ variable "common_tags" {
 
 variable "asp_name" {
   type = "string"
-  description = "App Service Plan (ASP) to use for the webapp, 'use_shared' to make use of the shared ASP"
-  default = "use_shared"
+  description = "App Service Plan (ASP) to use for the webapp"
+  default = ""
 }
 
 variable "asp_rg" {
   type = "string"
-  description = "App Service Plan (ASP) resource group for 'asp_name', 'use_shared' to make use of the shared resource group"
-  default = "use_shared"
+  description = "App Service Plan (ASP) resource group for 'asp_name'"
+  default = ""
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDM-2635



* Remove any fancy self determination of the shared ASP name and RG.
* Specify each env individually for single or shared ASP in their tfvars
file
* Use "" empty asp_rg and asp_name to get preview to do the correct
thing by default and to ensure that we specify each individually.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```