### PR TITLE
[PREVIEW] Lock nodejs to version 8.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.1.4
+FROM node:8-alpine
 MAINTAINER https://github.com/hmcts/ccd-admin-web
 
 RUN mkdir -p /usr/src/app

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": ">=7.10.1"
+    "node": "^8.9.4"
   },
   "scripts": {
     "setup": "gulp sass copy-files",


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDM-3073


Rationale:
- WebApps default available is 8.9.4 but 8.11.1 is available, so keep up
with what is available on Azure
- Docker based images are always the latest on the 8.x branch, with
nothing earlier.




**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```