### PR TITLE
Use 8.12.0-slim instead of 8-alpine images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,22 @@ MAINTAINER https://github.com/hmcts/ccd-admin-web
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
+ARG BUILD_DEPS='bzip2 patch'
+
 COPY package.json yarn.lock .snyk /usr/src/app/
-RUN yarn install
+RUN apt-get update && apt-get install -y $BUILD_DEPS --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/* \
+    && yarn install
 
 COPY src/main /usr/src/app/src/main
 COPY config /usr/src/app/config
 
 COPY gulpfile.js tsconfig.json /usr/src/app/
 RUN yarn sass
+
+RUN rm -rf node_modules \
+    && yarn install --production \
+    && apt-get purge -y --auto-remove $BUILD_DEPS
 
 # TODO: expose the right port for your application
 EXPOSE 3100

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-alpine
+FROM node:8.12.0-slim
 MAINTAINER https://github.com/hmcts/ccd-admin-web
 
 RUN mkdir -p /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,8 @@ MAINTAINER https://github.com/hmcts/ccd-admin-web
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-RUN apk add patch
-
 COPY package.json yarn.lock .snyk /usr/src/app/
 RUN yarn install
-
-RUN apk del patch
 
 COPY src/main /usr/src/app/src/main
 COPY config /usr/src/app/config


### PR DESCRIPTION
"due to an issue with Kubernetes DNS, please use debian slim-based Node
images for your front-end Docker images (e.g. `node:8.12.0-slim,
node:10.11.0-slim`)" ... timw

Also lock our images to a specific Node version instead of an open
version.




https://tools.hmcts.net/jira/browse/RDM-3128





**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```