### PR TITLE
RDM-4252: Improve handling and display of errors on Import Definition page

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "jquery-validation": "^1.17.0",
     "jsdom": "^11.11.0",
     "jwt-decode": "^2.2.0",
-    "multer": "^1.3.0",
+    "multer": "^1.4.1",
     "node-fetch": "^2.1.2",
     "node-sass": "^4.9.3",
     "nunjucks": "^3.0.1",

--- a/src/main/app.test.ts
+++ b/src/main/app.test.ts
@@ -6,6 +6,7 @@ import * as expressNunjucks from "express-nunjucks";
 import * as path from "path";
 import * as favicon from "serve-favicon";
 import { importAll } from "./import-all/index";
+
 const cookieSession = require("cookie-session");
 const env = process.env.NODE_ENV || "development";
 export const appTest: express.Express = express();
@@ -17,6 +18,7 @@ appTest.use(cookieSession({
   keys: ["key1", "key2"],
   name: "session",
 }));
+
 // setup logging of HTTP requests
 appTest.use(Express.accessLogger());
 
@@ -34,7 +36,6 @@ appTest.use(favicon(path.join(__dirname, "/public/img/favicon.ico")));
 appTest.use(bodyParser.json());
 appTest.use(bodyParser.urlencoded({ extended: false }));
 appTest.use(cookieParser());
-appTest.use(express.static(path.join(__dirname, "public")));
 
 expressNunjucks(appTest);
 
@@ -64,12 +65,12 @@ appTest.use((req, res) => {
 
 // error handler
 appTest.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
-  logger.error(`${err.stack || err}`);
+  logger.error(`${err.stack || err.error}`);
 
   // set locals
   res.locals.message = err.message;
   res.locals.error = err;
 
   res.status(err.status || 500);
-  req.authentication ? res.render("home") : res.render("error");
+  res.render("error");
 });

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -50,7 +50,6 @@ app.use(favicon(path.join(__dirname, "/public/img/favicon.ico")));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());
-app.use(express.static(path.join(__dirname, "public")));
 new Helmet(config.get<HelmetConfig>("security")).enableFor(app);
 
 expressNunjucks(app);
@@ -96,5 +95,5 @@ app.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
   }
 
   res.status(err.status || 500);
-  req.authentication && req.authentication.user ? res.render("importDefinition") : res.render("error");
+  res.render("error");
 });

--- a/src/main/routes/importDefinition.ts
+++ b/src/main/routes/importDefinition.ts
@@ -23,7 +23,11 @@ const url = config.get("adminWeb.import_audits_url");
 router.post("/import", (req, res, next) => {
   upload(req, res, (err) => {
     if (err) {
-      next(err);
+      // Construct error message manually, since err cannot be passed via req.session.error (it is cleared on redirect)
+      req.session.error = err.name + ": " + err.message;
+
+      // Redirect back to /import, to let the Import Definition page handle displaying the error message
+      res.redirect(302, "/import");
     } else if (req.file === undefined) {
       req.session.error = "No file selected! Please select a Definition spreadsheet to import";
       res.redirect(302, "/import");

--- a/src/main/routes/importDefinition.ts
+++ b/src/main/routes/importDefinition.ts
@@ -31,7 +31,7 @@ router.post("/import", (req, res, next) => {
       uploadFile(req)
         .then((response) => {
           res.status(201);
-          res.render("home", { response });
+          res.render("importDefinition", { response });
         })
         .catch((error) => {
           req.session.error = {

--- a/src/main/routes/importDefinition.ts
+++ b/src/main/routes/importDefinition.ts
@@ -24,6 +24,9 @@ router.post("/import", (req, res, next) => {
   upload(req, res, (err) => {
     if (err) {
       next(err);
+    } else if (req.file === undefined) {
+      req.session.error = "No file selected! Please select a Definition spreadsheet to import";
+      res.redirect(302, "/import");
     } else {
       uploadFile(req)
         .then((response) => {
@@ -31,8 +34,12 @@ router.post("/import", (req, res, next) => {
           res.render("home", { response });
         })
         .catch((error) => {
-          // Call the next middleware, which is the error handler
-          next(error);
+          req.session.error = {
+            message: error.message ? error.message : "Bad Request",
+            status: error.status ? error.status : 400,
+            text: error.response ? error.response.text : "An error occurred on import",
+          };
+          res.redirect(302, "/import");
         });
     }
   });

--- a/src/main/views/importDefinition.html
+++ b/src/main/views/importDefinition.html
@@ -1,4 +1,5 @@
 {% extends "layout_template.html" %}
+{% from "macros/formElements.html" import errorDisplay %}
 {% block content %}
 {% include "menu.html" %}
 <h2 class="heading-large padding">Import Case Definition</h2>
@@ -8,7 +9,11 @@
     <form action="/import" method="post" enctype="multipart/form-data">
       <div class="form-group">
         {% include "response.html" %}
-        {% include "error-message.html" %}
+        {% if error %}
+          <div class="error-summary govuk-error-message">
+            {{ errorDisplay(error) }}
+          </div>
+        {% endif %}
         <input type="file" id="file" name="file" accept=".xlsx"/>
       </div>
       <div class="form-group">

--- a/src/main/views/macros/formElements.html
+++ b/src/main/views/macros/formElements.html
@@ -104,3 +104,12 @@
        </fieldset>
     </div>
 {% endmacro %}
+
+{% macro errorDisplay(error) %}
+  {% if error.status %}
+    <p>{{ error.message }} ({{ error.status }})</p>
+  {% else %}
+    <p>{{ error }}</p>
+  {% endif %}
+<p>{{ error.response.text if error.response else error.text }}</p>
+{% endmacro %}

--- a/src/main/views/response.html
+++ b/src/main/views/response.html
@@ -1,3 +1,3 @@
 {% if not error %}
- {{ response.text if response else "Choose file containing case definitions" }}
+<p>{{ response.text if response else "Choose file containing case definitions" }}</p>
 {% endif %}

--- a/src/test/routes/confirmDeleteItem.spec.ts
+++ b/src/test/routes/confirmDeleteItem.spec.ts
@@ -17,7 +17,7 @@ describe("Confirm Delete page", () => {
   describe("on GET /deleteitem", () => {
     const CCD_IMPORT_ROLE = "ccd-import";
 
-    it("should redirect to Import page when not authenticated", () => {
+    it("should redirect to IdAM login page when not authenticated", () => {
       return request(app)
         .get("/deleteitem")
         .then((res) => {

--- a/src/test/routes/importDefinition.spec.ts
+++ b/src/test/routes/importDefinition.spec.ts
@@ -100,8 +100,12 @@ describe("Import Definition page", () => {
       idamServiceMock.resolveRetrieveUserFor("1", CCD_IMPORT_ROLE);
       idamServiceMock.resolveRetrieveServiceToken();
 
-      mock("http://localhost:4451/import")
-        .post("")
+      mock("http://localhost:4451")
+        .get("/api/idam/adminweb/authorization")
+        .reply(200, [{}]);
+
+      mock("http://localhost:4451")
+        .post("/import")
         .reply(201, "Definition imported");
 
       const file = {
@@ -125,8 +129,12 @@ describe("Import Definition page", () => {
       idamServiceMock.resolveRetrieveUserFor("1", CCD_IMPORT_ROLE);
       idamServiceMock.resolveRetrieveServiceToken();
 
-      const apiCall = mock("http://localhost:4451/import")
-        .post("")
+      mock("http://localhost:4451")
+        .get("/api/idam/adminweb/authorization")
+        .reply(200, [{}]);
+
+      const apiCall = mock("http://localhost:4451")
+        .post("/import")
         .reply(201, "Definition imported");
 
       const file = {
@@ -151,8 +159,12 @@ describe("Import Definition page", () => {
       idamServiceMock.resolveRetrieveUserFor("1", CCD_IMPORT_ROLE);
       idamServiceMock.resolveRetrieveServiceToken();
 
-      const apiCall = mock("http://localhost:4451/import")
-        .post("")
+      mock("http://localhost:4451")
+        .get("/api/idam/adminweb/authorization")
+        .reply(200, [{}]);
+
+      const apiCall = mock("http://localhost:4451")
+        .post("/import")
         .reply(201, "Definition imported");
 
       return request(app)
@@ -171,8 +183,12 @@ describe("Import Definition page", () => {
       idamServiceMock.resolveRetrieveUserFor("1", CCD_IMPORT_ROLE);
       idamServiceMock.resolveRetrieveServiceToken();
 
-      const apiCall = mock("http://localhost:4451/import")
-        .post("")
+      mock("http://localhost:4451")
+        .get("/api/idam/adminweb/authorization")
+        .reply(200, [{}]);
+
+      const apiCall = mock("http://localhost:4451")
+        .post("/import")
         .replyWithError(500, "Error on Definition import");
 
       const file = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -328,9 +328,10 @@ anymatch@^1.3.0:
     micromatch "^2.1.5"
     normalize-path "^2.0.0"
 
-append-field@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/append-field/-/append-field-0.1.0.tgz#6ddc58fa083c7bc545d3c5995b2830cc2366d44a"
+append-field@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/append-field/-/append-field-1.0.0.tgz#1e3440e915f0b1203d23748e78edd7b9b5b43e56"
+  integrity sha1-HjRA6RXwsSA9I3SOeO3XubW0PlY=
 
 append-transform@^0.4.0:
   version "0.4.0"
@@ -1158,9 +1159,10 @@ concat-stream@1.6.0, concat-stream@^1.4.6:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-concat-stream@^1.5.0, concat-stream@^1.6.0:
+concat-stream@^1.5.2, concat-stream@^1.6.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
+  integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
   dependencies:
     buffer-from "^1.0.0"
     inherits "^2.0.3"
@@ -4893,15 +4895,16 @@ ms@2.1.1, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-multer@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/multer/-/multer-1.3.0.tgz#092b2670f6846fa4914965efc8cf94c20fec6cd2"
+multer@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/multer/-/multer-1.4.1.tgz#24b12a416a22fec2ade810539184bf138720159e"
+  integrity sha512-zzOLNRxzszwd+61JFuAo0fxdQfvku12aNJgnla0AQ+hHxFmfc/B7jBVuPr5Rmvu46Jze/iJrFpSOsD7afO8SDw==
   dependencies:
-    append-field "^0.1.0"
+    append-field "^1.0.0"
     busboy "^0.2.11"
-    concat-stream "^1.5.0"
+    concat-stream "^1.5.2"
     mkdirp "^0.5.1"
-    object-assign "^3.0.0"
+    object-assign "^4.1.1"
     on-finished "^2.3.0"
     type-is "^1.6.4"
     xtend "^4.0.0"


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/RDM-4252.

### Change description ###
Change error handling to be done directly on the page, instead of using the error handler middleware. Render error messages using the same style as elsewhere in the application.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
