### PR TITLE
RDM-4265: DefaultHidden column warning on Definition import

### DIFF
--- a/src/main/app.test-admin-web-roles-authorized.ts
+++ b/src/main/app.test-admin-web-roles-authorized.ts
@@ -36,7 +36,13 @@ appTestWithAuthorizedAdminWebRoles.use(bodyParser.urlencoded({ extended: false }
 appTestWithAuthorizedAdminWebRoles.use(cookieParser());
 appTestWithAuthorizedAdminWebRoles.use(express.static(path.join(__dirname, "public")));
 
-expressNunjucks(appTestWithAuthorizedAdminWebRoles);
+expressNunjucks(appTestWithAuthorizedAdminWebRoles, {
+  filters: {
+    split: (str, separator) => {
+      return str.split(separator);
+    },
+  },
+});
 
 // Allow application to work correctly behind a proxy (needed to pick up correct request protocol)
 appTestWithAuthorizedAdminWebRoles.enable("trust proxy");

--- a/src/main/app.test.ts
+++ b/src/main/app.test.ts
@@ -37,7 +37,13 @@ appTest.use(bodyParser.json());
 appTest.use(bodyParser.urlencoded({ extended: false }));
 appTest.use(cookieParser());
 
-expressNunjucks(appTest);
+expressNunjucks(appTest, {
+  filters: {
+    split: (str, separator) => {
+      return str.split(separator);
+    },
+  },
+});
 
 // Allow application to work correctly behind a proxy (needed to pick up correct request protocol)
 appTest.enable("trust proxy");

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -53,7 +53,13 @@ app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());
 new Helmet(config.get<HelmetConfig>("security")).enableFor(app);
 
-expressNunjucks(app);
+expressNunjucks(app, {
+  filters: {
+    split: (str, separator) => {
+      return str.split(separator);
+    },
+  },
+});
 
 // Allow application to work correctly behind a proxy (needed to pick up correct request protocol)
 app.enable("trust proxy");

--- a/src/main/routes/importDefinition.ts
+++ b/src/main/routes/importDefinition.ts
@@ -38,7 +38,10 @@ router.post("/import", (req, res, next) => {
         uploadFile(req)
           .then((response) => {
             res.status(201);
-            res.render("importDefinition", {response});
+            const responseContent: { [k: string]: any } = {};
+            responseContent.user = JSON.stringify(req.authentication.user);
+            responseContent.response = response;
+            res.render("importDefinition", responseContent);
           })
           .catch((error) => {
             req.session.error = {

--- a/src/main/views/response.html
+++ b/src/main/views/response.html
@@ -1,3 +1,11 @@
 {% if not error %}
 <p>{{ response.text if response else "Choose file containing case definitions" }}</p>
 {% endif %}
+{% if response.headers["definition-import-warnings"] %}
+<div>Warnings:</div>
+<ul>
+  {% for message in response.headers["definition-import-warnings"] | split(",") %}
+  <li>{{ message }}</li>
+  {% endfor %}
+</ul>
+{% endif %}


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/RDM-4265.

### Change description ###
Display a list of import warnings returned by Definition Store API, on importing a Definition containing the legacy `DefaultHidden` column on any spreadsheet tabs.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
