### PR TITLE
pointing to master branch as version of java container is 9 in master

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -55,7 +55,7 @@ data "azurerm_key_vault_secret" "oauth2_client_secret" {
 }
 
 module "ccd-admin-web" {
-  source = "git@github.com:hmcts/cnp-module-webapp?ref=Bump-JCV"
+  source = "git@github.com:hmcts/cnp-module-webapp?ref=master"
   product = "${local.app_full_name}"
   location = "${var.location}"
   appinsights_location = "${var.location}"


### PR DESCRIPTION
Build fix for the below error

08:13:03  non whitelisted resources:
08:13:03  ```
08:13:03  Error matching modules: [{ccd-admin-web git@github.com:hmcts/cnp-module-webapp?ref=Bump-JCV  {main.tf 57}}]
08:13:03  
08:13:03  ```