### PR TITLE
Fortify and CVE fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,8 @@
     "trim-newlines": "^3.0.1",
     "glob-parent": "^5.1.2",
     "normalize-url": "^4.5.1",
-    "ws": "^6.2.2"
+    "ws": "^6.2.2",
+    "tar": "^6.1.2"
   },
   "nyc": {
     "extension": [

--- a/src/main/routes/deleteDefinition.ts
+++ b/src/main/routes/deleteDefinition.ts
@@ -1,6 +1,7 @@
 import { deleteDefinition } from "../service/delete-definition-service";
 import { deleteSessionVariables } from "../util/clearSession";
 import { error_unauthorized_role } from "../util/error_unauthorized_role";
+import { sanitize } from "../util/sanitize";
 import router from "./home";
 
 const errorPage = "error";
@@ -19,8 +20,8 @@ router.post("/deletedefinition", (req, res, next) => {
                 status: 400, text: error.rawResponse ? error.rawResponse :
                     "Unexpected error : Please contact your administrator",
             };
-            res.redirect(302, `/deleteitem?item=${req.body.itemToDelete}&jurisdictionId=${req.body.jurisdictionId}`
-              + `&version=${req.body.definitionVersion}`);
+            res.redirect(302, `/deleteitem?item=${sanitize(req.body.itemToDelete)}&jurisdictionId=${sanitize(req.body.jurisdictionId)}`
+              + `&version=${sanitize(req.body.definitionVersion)}`);
         });
     } else if (req.body.deleteItem === "No") {
         deleteSessionVariables(req);
@@ -28,8 +29,8 @@ router.post("/deletedefinition", (req, res, next) => {
     } else {
         deleteSessionVariables(req);
         req.session.response = { error: "Please choose Yes or No" };
-        res.redirect(302, `/deleteitem?item=${req.body.itemToDelete}&jurisdictionId=${req.body.jurisdictionId}`
-          + `&version=${req.body.definitionVersion}`);
+        res.redirect(302, `/deleteitem?item=${sanitize(req.body.itemToDelete)}&jurisdictionId=${sanitize(req.body.jurisdictionId)}`
+          + `&version=${sanitize(req.body.definitionVersion)}`);
     }
   } else {
     res.render(errorPage, error_unauthorized_role(req));

--- a/src/main/routes/deleteUser.ts
+++ b/src/main/routes/deleteUser.ts
@@ -1,6 +1,7 @@
 import { error_unauthorized_role } from "../util/error_unauthorized_role";
 import { deleteSessionVariables } from "../util/clearSession";
 import { deleteUserProfile } from "../service/delete-user-service";
+import { sanitize } from "../util/sanitize";
 import router from "./home";
 
 const errorPage = "error";
@@ -20,7 +21,7 @@ router.post("/deleteuser", (req, res, next) => {
           status: 400, text: error.rawResponse ? error.rawResponse :
             "Unexpected error : Please contact your administrator",
         };
-        res.redirect(302, `/deleteitem?item=${req.body.itemToDelete}&idamId=${req.body.idamId}`);
+        res.redirect(302, `/deleteitem?item=${sanitize(req.body.itemToDelete)}&idamId=${sanitize(req.body.idamId)}`);
       });
     } else if (req.body.deleteItem === "No") {
       deleteSessionVariables(req);
@@ -28,7 +29,7 @@ router.post("/deleteuser", (req, res, next) => {
     } else {
       deleteSessionVariables(req);
       req.session.response = {error: "Please choose Yes or No"};
-      res.redirect(302, `/deleteitem?item=${req.body.itemToDelete}&idamId=${req.body.idamId}`);
+      res.redirect(302, `/deleteitem?item=${sanitize(req.body.itemToDelete)}&idamId=${sanitize(req.body.idamId)}`);
     }
   } else {
     res.render(errorPage, error_unauthorized_role(req));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1145,13 +1145,6 @@ blob@0.0.5:
   resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.5.tgz#d680eeef25f8cd91ad533f5b01eed48e64caf683"
   integrity sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==
 
-block-stream@*:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
-  integrity sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=
-  dependencies:
-    inherits "~2.0.0"
-
 bluebird@^3.3.0:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
@@ -1573,6 +1566,11 @@ chokidar@^3.0.0, chokidar@^3.2.2:
     readdirp "~3.3.0"
   optionalDependencies:
     fsevents "~2.1.2"
+
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
 ci-info@^1.5.0:
   version "1.6.0"
@@ -3484,6 +3482,13 @@ fs-extra@^7.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-minipass@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
+  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
+  dependencies:
+    minipass "^3.0.0"
+
 fs-mkdirp-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz#0b7815fc3201c6a69e14db98ce098c16935259eb"
@@ -3510,7 +3515,7 @@ fsevents@~2.1.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.2.tgz#4c0a1fb34bc68e543b4b82a9ec392bfbda840805"
   integrity sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==
 
-fstream@^1.0.0, fstream@^1.0.12:
+fstream@^1.0.0:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
   integrity sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
@@ -5958,6 +5963,21 @@ minimist@0.0.8, minimist@1.1.x, minimist@^1.1.0, minimist@^1.1.3, minimist@^1.2.
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
+minipass@^3.0.0:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.3.tgz#7d42ff1f39635482e15f9cdb53184deebd5815fd"
+  integrity sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==
+  dependencies:
+    yallist "^4.0.0"
+
+minizlib@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
+  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
+  dependencies:
+    minipass "^3.0.0"
+    yallist "^4.0.0"
+
 mixin-deep@^1.2.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
@@ -5973,7 +5993,7 @@ mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mkdirp@^1.0.4:
+mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -8921,14 +8941,17 @@ tar-stream@^2.1.2:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@^2.0.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.2.tgz#0ca8848562c7299b8b446ff6a4d60cdbb23edc40"
-  integrity sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==
+tar@^2.0.0, tar@^6.1.2:
+  version "6.1.6"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.6.tgz#c23d797b0a1efe5d479b1490805c5443f3560c5d"
+  integrity sha512-oaWyu5dQbHaYcyZCTfyPpC+VmI62/OM2RTUYavTk1MDr1cwW5Boi3baeYQKiZbY2uSQJGr+iMOzb/JFxLrft+g==
   dependencies:
-    block-stream "*"
-    fstream "^1.0.12"
-    inherits "2"
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^3.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
 
 tcomb-validation@^3.3.0:
   version "3.4.1"


### PR DESCRIPTION
### [CCD-1722](https://tools.hmcts.net/jira/browse/CCD-1722) ###
### [CCD-1768](https://tools.hmcts.net/jira/browse/CCD-1768) ###
### [CCD-1769](https://tools.hmcts.net/jira/browse/CCD-1769) ###

### Change description ###
Reuse xss-filters to sanatize redirects to fix fortify issues
Fixed Tar version due to CVE's raised against transient dependency


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
