### PR TITLE
CCD-2161: Address CVE-2021-23807

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,8 @@
     "set-value": "^4.0.1",
     "ssh2": "^1.4.0",
     "vm2": "^3.9.5",
-    "validator": "^13.7.0"
+    "validator": "^13.7.0",
+    "is-my-json-valid": "^2.20.6"
   },
   "nyc": {
     "extension": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4697,15 +4697,15 @@ is-my-ip-valid@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz#7b351b8e8edd4d3995d4d066680e664d94696824"
   integrity sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==
 
-is-my-json-valid@^2.10.0:
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.20.0.tgz#1345a6fca3e8daefc10d0fa77067f54cedafd59a"
-  integrity sha512-XTHBZSIIxNsIsZXg7XB5l8z/OBFosl1Wao4tXLpeC7eKU4Vm/kdop2azkPqULwnfGQjmeDIyey9g7afMMtdWAA==
+is-my-json-valid@^2.10.0, is-my-json-valid@^2.20.6:
+  version "2.20.6"
+  resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.20.6.tgz#a9d89e56a36493c77bda1440d69ae0dc46a08387"
+  integrity sha512-1JQwulVNjx8UqkPE/bqDaxtH4PXCe/2VRh/y3p99heOV87HG4Id5/VfDswd+YiAfHcRTfDlWgISycnHuhZq1aw==
   dependencies:
     generate-function "^2.0.0"
     generate-object-property "^1.1.0"
     is-my-ip-valid "^1.0.0"
-    jsonpointer "^4.0.0"
+    jsonpointer "^5.0.0"
     xtend "^4.0.0"
 
 is-negated-glob@^1.0.0:
@@ -5134,10 +5134,10 @@ jsonify@~0.0.0:
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
-jsonpointer@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
-  integrity sha1-T9kss04OnbPInIYi7PUfm5eMbLk=
+jsonpointer@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-5.0.0.tgz#f802669a524ec4805fa7389eadbc9921d5dc8072"
+  integrity sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==
 
 jsonwebtoken@^8.3.0:
   version "8.5.1"


### PR DESCRIPTION
### JIRA link ###
CCD-2161 (https://tools.hmcts.net/jira/browse/CCD-2161)


### Change description ###
- Updated package.json.  Added resolution for is-my-json-valid to use version ^2.20.6.  This version of is-my-json-valid uses version ^5.0.0 of jsonpointer which fixes the vulnerability reported in CVE-2021-23807.
- Regenerated yarn.lock file.
- No suppression to remove from yarn-audit-known-issues as issue is only related to a dev dependency and therefore didn't need to be suppressed.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
