### PR TITLE
CCD-2535: Temporarily ignore Fortify scan results

### DIFF
--- a/src/test/java/build.gradle
+++ b/src/test/java/build.gradle
@@ -26,6 +26,6 @@ task fortifyScan(type: JavaExec)  {
   main = "uk.gov.hmcts.fortifyclient.FortifyClientMainApp"
   classpath += sourceSets.test.runtimeClasspath
   jvmArgs = ['--add-opens=java.base/java.lang.reflect=ALL-UNNAMED']
-  // Uncomment the line below to prevent the build from failing if the Fortify scan detects issues
-  //ignoreExitValue = true
+  // The line below prevents the build from failing if the Fortify scan detects issues
+  ignoreExitValue = true
 }


### PR DESCRIPTION
### JIRA link ###
CCD-2535 (https://tools.hmcts.net/jira/browse/CCD-2535)


### Change description ###
Temporarily changed fortifyScan task in build.gradle so that it ignores the results of the scan.  This will be reverted when issue flagged by Fortify is addressed.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
