### PR TITLE
CVE-2020-7751 fix with pathval:1.1.1 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,8 @@
     "copy-props": "^2.0.5",
     "ajv": "^6.12.3",
     "minimist": "^1.2.6",
-    "moment": "^2.29.2"
+    "moment": "^2.29.2",
+    "pathval": "^1.1.1"
   },
   "nyc": {
     "extension": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -7301,12 +7301,7 @@ path@^0.12.7:
     process "^0.11.1"
     util "^0.10.3"
 
-pathval@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
-  integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
-
-pathval@^1.1.1:
+pathval@^1.1.0, pathval@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
   integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==


### PR DESCRIPTION

### JIRA link ###
https://tools.hmcts.net/jira/browse/CCD-3134


### Change description ###

pathval before version 1.1.1 is vulnerable to prototype pollution.upgrading to relevant version.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
