### PR TITLE
Re-onboard CVE dashboard ingestion

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -5,7 +5,7 @@ properties(
          pipelineTriggers([[$class: 'GitHubPushTrigger']])]
 )
 
-@Library("Infrastructure@cve-dashboard-v2")
+@Library("Infrastructure@cve-dashboard")
 
 def yarnBuilder = new uk.gov.hmcts.contino.YarnBuilder(this)
 def product = "ccd"


### PR DESCRIPTION
## Summary
- move the shared Jenkins library from cve-dashboard-v2 to cve-dashboard
- preserve the existing CVE dashboard ingestion configuration

## Testing
- Jenkinsfile-only configuration change